### PR TITLE
Add helpers to check if a visualization makes queries or has filters

### DIFF
--- a/kbncontent.go
+++ b/kbncontent.go
@@ -111,6 +111,46 @@ func (v VisualizationDescriptor) SemanticType() string {
 	}
 }
 
+// CanUseFilter returns true if the visualization makes queries.
+func (v VisualizationDescriptor) CanUseFilter() bool {
+	switch v.SavedObjectType {
+	case "search":
+		return false
+	case "visualization":
+		if v.isTSVB() {
+			switch v.TSVBType() {
+			case "markdown":
+				return false
+			}
+		} else {
+			switch v.Type() {
+			case "markdown":
+				return false
+			}
+
+		}
+	}
+
+	return true
+}
+
+// HasFilters returns true if the dashboard has defined filters.
+func (v VisualizationDescriptor) HasFilters() bool {
+	m := objx.Map(v.Doc)
+
+	query := m.Get("embeddableConfig.attributes.state.query.query")
+	if query.IsStr() && query.Str() != "" {
+		return true
+	}
+
+	filters := m.Get("embeddableConfig.attributes.state.filters")
+	if filters.IsObjxMapSlice() && len(filters.ObjxMapSlice()) > 0 {
+		return true
+	}
+
+	return false
+}
+
 // TSVBType returns the TSVB sub type (gauge, markdown, etc)
 // TSVB visualizations are always Type "metrics"
 func (v VisualizationDescriptor) TSVBType() string {

--- a/kbncontent.go
+++ b/kbncontent.go
@@ -127,9 +127,12 @@ func (v VisualizationDescriptor) CanUseFilter() bool {
 }
 
 // HasFilters returns true if the visualization has defined filters.
-func (v VisualizationDescriptor) HasFilters() bool {
+func (v VisualizationDescriptor) HasFilters() (bool, error) {
 	m := objx.Map(v.Doc)
-	deserializeSubPaths(m)
+	err := deserializeSubPaths(m)
+	if err != nil {
+		return false, err
+	}
 
 	queryPaths := []string{
 		"attributes.kibanaSavedObjectMeta.searchSourceJSON.query.query",
@@ -140,7 +143,7 @@ func (v VisualizationDescriptor) HasFilters() bool {
 	for _, path := range queryPaths {
 		query := m.Get(path)
 		if query.IsStr() && query.Str() != "" {
-			return true
+			return true, nil
 		}
 	}
 
@@ -153,11 +156,11 @@ func (v VisualizationDescriptor) HasFilters() bool {
 	for _, path := range filterPaths {
 		filters := m.Get(path)
 		if filters.IsObjxMapSlice() && len(filters.ObjxMapSlice()) > 0 {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 // TSVBType returns the TSVB sub type (gauge, markdown, etc)

--- a/kbncontent.go
+++ b/kbncontent.go
@@ -117,35 +117,44 @@ func (v VisualizationDescriptor) CanUseFilter() bool {
 	case "search":
 		return false
 	case "visualization":
-		if v.isTSVB() {
-			switch v.TSVBType() {
-			case "markdown":
-				return false
-			}
-		} else {
-			switch v.Type() {
-			case "markdown":
-				return false
-			}
-
+		switch v.Type() {
+		case "markdown":
+			return false
 		}
 	}
 
 	return true
 }
 
-// HasFilters returns true if the dashboard has defined filters.
+// HasFilters returns true if the visualization has defined filters.
 func (v VisualizationDescriptor) HasFilters() bool {
 	m := objx.Map(v.Doc)
+	deserializeSubPaths(m)
 
-	query := m.Get("embeddableConfig.attributes.state.query.query")
-	if query.IsStr() && query.Str() != "" {
-		return true
+	queryPaths := []string{
+		"attributes.kibanaSavedObjectMeta.searchSourceJSON.query.query",
+		"attributes.state.query.query",
+		"embeddableConfig.attributes.state.query.query",
+		"embeddableConfig.savedVis.data.searchSource.query.query",
+	}
+	for _, path := range queryPaths {
+		query := m.Get(path)
+		if query.IsStr() && query.Str() != "" {
+			return true
+		}
 	}
 
-	filters := m.Get("embeddableConfig.attributes.state.filters")
-	if filters.IsObjxMapSlice() && len(filters.ObjxMapSlice()) > 0 {
-		return true
+	filterPaths := []string{
+		"attributes.state.filters",
+		"embeddableConfig.attributes.state.filters",
+		"embeddableConfig.savedVis.data.searchSource.filter",
+		"attributes.kibanaSavedObjectMeta.searchSourceJSON.filter",
+	}
+	for _, path := range filterPaths {
+		filters := m.Get(path)
+		if filters.IsObjxMapSlice() && len(filters.ObjxMapSlice()) > 0 {
+			return true
+		}
 	}
 
 	return false

--- a/kbncontent_test.go
+++ b/kbncontent_test.go
@@ -28,7 +28,7 @@ func TestDescribeByValueDashboardPanels(t *testing.T) {
 		{title: "", editor: "Aggs-based", legacy: false, soType: "visualization", visType: "markdown", tsvbType: ""},
 		{title: "", editor: "Aggs-based", legacy: false, soType: "visualization", visType: "markdown", tsvbType: ""},
 		{title: "TSVB time series", editor: "TSVB", legacy: true, soType: "visualization", visType: "metrics", tsvbType: "timeseries", makesQueries: true},
-		{title: "TSVB gauge", editor: "TSVB", legacy: true, soType: "visualization", visType: "metrics", tsvbType: "gauge", makesQueries: true},
+		{title: "TSVB gauge", editor: "TSVB", legacy: true, soType: "visualization", visType: "metrics", tsvbType: "gauge", makesQueries: true, hasFilters: true},
 		{title: "", editor: "Aggs-based", legacy: false, soType: "visualization", visType: "markdown", tsvbType: ""},
 		{title: "Aggs-based table", editor: "Aggs-based", legacy: true, soType: "visualization", visType: "table", tsvbType: "", makesQueries: true},
 		{title: "Aggs-based tag cloud", editor: "Aggs-based", legacy: true, soType: "visualization", visType: "tagcloud", tsvbType: "", makesQueries: true},
@@ -72,6 +72,9 @@ func TestDescribeByValueDashboardPanels(t *testing.T) {
 		assert.Equalf(t, expected[i].visType, desc.Type(), "Type() should match expected in \"%s\" (%s)", title, editor)
 		assert.Equalf(t, expected[i].tsvbType, desc.TSVBType(), "TSVBType() should match expected in \"%s\" (%s)", title, editor)
 		assert.Equal(t, expected[i].makesQueries, desc.CanUseFilter(), "MakesQueries() should match expected in \"%s\" (%s)", title, editor)
-		assert.Equal(t, expected[i].hasFilters, desc.HasFilters(), "MakesQueries() should match expected in \"%s\" (%s)", title, editor)
+		hasFilters, err := desc.HasFilters()
+		if assert.NoError(t, err) {
+			assert.Equal(t, expected[i].hasFilters, hasFilters, "HasFilters() should match expected in \"%s\" (%s)", title, editor)
+		}
 	}
 }

--- a/kbncontent_test.go
+++ b/kbncontent_test.go
@@ -10,28 +10,30 @@ import (
 
 func TestDescribeByValueDashboardPanels(t *testing.T) {
 	expected := []struct {
-		title    string
-		editor   string
-		legacy   bool
-		soType   string
-		visType  string
-		tsvbType string
+		title        string
+		editor       string
+		legacy       bool
+		soType       string
+		visType      string
+		tsvbType     string
+		makesQueries bool
+		hasFilters   bool
 	}{
-		{title: "Legacy input control vis", editor: "Aggs-based", legacy: false, soType: "visualization", visType: "input_control_vis", tsvbType: ""},
+		{title: "Legacy input control vis", editor: "Aggs-based", legacy: false, soType: "visualization", visType: "input_control_vis", tsvbType: "", makesQueries: true},
 		{title: "", editor: "Aggs-based", legacy: false, soType: "visualization", visType: "markdown", tsvbType: ""},
-		{title: "", editor: "Lens", legacy: false, soType: "lens", visType: "", tsvbType: ""},
-		{title: "Vega time series", editor: "Vega", legacy: false, soType: "visualization", visType: "vega", tsvbType: ""},
-		{title: "", editor: "Maps", legacy: false, soType: "map", visType: "", tsvbType: ""},
+		{title: "", editor: "Lens", legacy: false, soType: "lens", visType: "", tsvbType: "", makesQueries: true},
+		{title: "Vega time series", editor: "Vega", legacy: false, soType: "visualization", visType: "vega", tsvbType: "", makesQueries: true},
+		{title: "", editor: "Maps", legacy: false, soType: "map", visType: "", tsvbType: "", makesQueries: true},
 		{title: "TSVB Markdown", editor: "TSVB", legacy: false, soType: "visualization", visType: "metrics", tsvbType: "markdown"},
 		{title: "", editor: "Aggs-based", legacy: false, soType: "visualization", visType: "markdown", tsvbType: ""},
 		{title: "", editor: "Aggs-based", legacy: false, soType: "visualization", visType: "markdown", tsvbType: ""},
-		{title: "TSVB time series", editor: "TSVB", legacy: true, soType: "visualization", visType: "metrics", tsvbType: "timeseries"},
-		{title: "TSVB gauge", editor: "TSVB", legacy: true, soType: "visualization", visType: "metrics", tsvbType: "gauge"},
+		{title: "TSVB time series", editor: "TSVB", legacy: true, soType: "visualization", visType: "metrics", tsvbType: "timeseries", makesQueries: true},
+		{title: "TSVB gauge", editor: "TSVB", legacy: true, soType: "visualization", visType: "metrics", tsvbType: "gauge", makesQueries: true},
 		{title: "", editor: "Aggs-based", legacy: false, soType: "visualization", visType: "markdown", tsvbType: ""},
-		{title: "Aggs-based table", editor: "Aggs-based", legacy: true, soType: "visualization", visType: "table", tsvbType: ""},
-		{title: "Aggs-based tag cloud", editor: "Aggs-based", legacy: true, soType: "visualization", visType: "tagcloud", tsvbType: ""},
-		{title: "", editor: "Aggs-based", legacy: true, soType: "visualization", visType: "heatmap", tsvbType: ""},
-		{title: "Timelion time series", editor: "Timelion", legacy: true, soType: "visualization", visType: "timelion", tsvbType: ""},
+		{title: "Aggs-based table", editor: "Aggs-based", legacy: true, soType: "visualization", visType: "table", tsvbType: "", makesQueries: true},
+		{title: "Aggs-based tag cloud", editor: "Aggs-based", legacy: true, soType: "visualization", visType: "tagcloud", tsvbType: "", makesQueries: true},
+		{title: "", editor: "Aggs-based", legacy: true, soType: "visualization", visType: "heatmap", tsvbType: "", makesQueries: true},
+		{title: "Timelion time series", editor: "Timelion", legacy: true, soType: "visualization", visType: "timelion", tsvbType: "", makesQueries: true},
 	}
 
 	content, err := ioutil.ReadFile("./testdata/dashboard.json")
@@ -64,10 +66,12 @@ func TestDescribeByValueDashboardPanels(t *testing.T) {
 		assert.Equalf(t, desc.SavedObjectType, expected[i].soType, "SavedObjectType should match expected in \"%s\" (%s)", title, editor)
 
 		// Methods
-		assert.Equalf(t, title, expected[i].title, "Title() should match expected in \"%s\" (%s)")
-		assert.Equalf(t, editor, expected[i].editor, "Editor() should match expected in \"%s\" (%s)")
-		assert.Equalf(t, desc.IsLegacy(), expected[i].legacy, "IsLegacy() should match expected in \"%s\" (%s)", title, editor)
-		assert.Equalf(t, desc.Type(), expected[i].visType, "Type() should match expected in \"%s\" (%s)", title, editor)
-		assert.Equalf(t, desc.TSVBType(), expected[i].tsvbType, "TSVBType() should match expected in \"%s\" (%s)", title, editor)
+		assert.Equalf(t, expected[i].title, title, "Title() should match expected in \"%s\" (%s)")
+		assert.Equalf(t, expected[i].editor, editor, "Editor() should match expected in \"%s\" (%s)")
+		assert.Equalf(t, expected[i].legacy, desc.IsLegacy(), "IsLegacy() should match expected in \"%s\" (%s)", title, editor)
+		assert.Equalf(t, expected[i].visType, desc.Type(), "Type() should match expected in \"%s\" (%s)", title, editor)
+		assert.Equalf(t, expected[i].tsvbType, desc.TSVBType(), "TSVBType() should match expected in \"%s\" (%s)", title, editor)
+		assert.Equal(t, expected[i].makesQueries, desc.CanUseFilter(), "MakesQueries() should match expected in \"%s\" (%s)", title, editor)
+		assert.Equal(t, expected[i].hasFilters, desc.HasFilters(), "MakesQueries() should match expected in \"%s\" (%s)", title, editor)
 	}
 }

--- a/kbncontent_test.go
+++ b/kbncontent_test.go
@@ -24,7 +24,7 @@ func TestDescribeByValueDashboardPanels(t *testing.T) {
 		{title: "", editor: "Lens", legacy: false, soType: "lens", visType: "", tsvbType: "", makesQueries: true},
 		{title: "Vega time series", editor: "Vega", legacy: false, soType: "visualization", visType: "vega", tsvbType: "", makesQueries: true},
 		{title: "", editor: "Maps", legacy: false, soType: "map", visType: "", tsvbType: "", makesQueries: true},
-		{title: "TSVB Markdown", editor: "TSVB", legacy: false, soType: "visualization", visType: "metrics", tsvbType: "markdown"},
+		{title: "TSVB Markdown", editor: "TSVB", legacy: false, soType: "visualization", visType: "metrics", tsvbType: "markdown", makesQueries: true},
 		{title: "", editor: "Aggs-based", legacy: false, soType: "visualization", visType: "markdown", tsvbType: ""},
 		{title: "", editor: "Aggs-based", legacy: false, soType: "visualization", visType: "markdown", tsvbType: ""},
 		{title: "TSVB time series", editor: "TSVB", legacy: true, soType: "visualization", visType: "metrics", tsvbType: "timeseries", makesQueries: true},

--- a/testdata/dashboard.json
+++ b/testdata/dashboard.json
@@ -580,7 +580,7 @@
                                 "filter": [],
                                 "query": {
                                     "language": "kuery",
-                                    "query": ""
+                                    "query": "data_stream.dataset: test.metrics"
                                 }
                             }
                         },


### PR DESCRIPTION
In https://github.com/elastic/package-spec/pull/687 we are loosing the restriction on dashboards to require filters, so dashboards whose all visualizations that make queries have filters, don't need to have a filter at the dashboard level.

Here we add two helper methods, one to check if a visualization can use filters, and another one to check if the visualization has filters.

Part of https://github.com/elastic/package-spec/issues/685